### PR TITLE
convertコマンドを実装

### DIFF
--- a/src/katima.nim
+++ b/src/katima.nim
@@ -12,12 +12,30 @@ proc repl(args: seq[string]) =
   runRepl()
 
 proc convert(
-  oldCharFormsSrc = "", newCharFormsSrc = "",
-    reversalSrc = "", args: seq[string]) =
-  if oldCharFormsSrc != "": echo oldCharFormsSrc.toOldForm
-  if newCharFormsSrc != "": echo newCharFormsSrc.toNewForm
-  if reversalSrc != "": echo reversalSrc.toReversal
+  oldCharFormsMode = false, newCharFormsMode = false, reversalMode = false,
+    args: seq[string]) =
+  ## convert the input to the specified forms
+  let src =
+    if args.len == 0:
+      stdin.readLine
+    else:
+      let srcFilePath = args[0]
+      var file = open(srcFilePath, FileMode.fmRead)
+      defer:
+        file.close()
+      file.readAll()
 
+  let dest =
+    if oldCharFormsMode:
+      src.toOldForm
+    elif newCharFormsMode:
+      src.toNewForm
+    elif reversalMode:
+      src.toReversal
+    else:
+      src
+
+  stdout.write dest
 
 when isMainModule:
   import cligen

--- a/src/katima.nim
+++ b/src/katima.nim
@@ -11,10 +11,17 @@ proc repl(args: seq[string]) =
   ## start the REPL mode
   runRepl()
 
+proc convert(
+  oldCharFormsSrc = "", newCharFormsSrc = "",
+    reversalSrc = "", args: seq[string]) =
+  if oldCharFormsSrc != "": echo oldCharFormsSrc.toOldForm
+  if newCharFormsSrc != "": echo newCharFormsSrc.toNewForm
+  if reversalSrc != "": echo reversalSrc.toReversal
+
 
 when isMainModule:
   import cligen
-  dispatchMulti([repl])
+  dispatchMulti([repl], [convert])
   # echo "医学".toOldForm
   # echo "醫學".toNewForm
   # echo "医學".toReversal

--- a/src/katima.nim
+++ b/src/katima.nim
@@ -35,7 +35,7 @@ proc convert(
     else:
       src
 
-  stdout.write dest
+  stdout.write(dest)
 
 when isMainModule:
   import cligen


### PR DESCRIPTION
# Feat
-  `convert` コマンドを実装 (#9)
    - `convert -o "foo"` または `convert -o "foo"` で `foo` を旧字体に変換し標準出力に出力する。
    - `convert -n "foo"` または `convert -n "foo"` で `foo` を新字体に変換し標準出力に出力する。
    - `convert -n "foo"` または `convert -o "foo"` で `foo` を旧字体は新字体に, 新字体は旧字体に変換し標準出力に出力する。